### PR TITLE
Fix mobile keyboard backspace in viewer

### DIFF
--- a/client/viewer.js
+++ b/client/viewer.js
@@ -21,6 +21,8 @@ let remoteViewport = { width: 1920, height: 1080 };
 let currentTabId = null;
 let hostMetrics = null;
 let isMobileInputMode = false;
+let lastMobileKeyboardValue = '';
+let mobileKeyboardRefocusPending = false;
 
 // --- Reconnect state ---
 let connectedPeerId = null;
@@ -505,12 +507,48 @@ function focusMobileKeyboardInput() {
   if (!mobileKeyboardInput) return;
   isMobileInputMode = true;
   mobileKeyboardInput.focus({ preventScroll: true });
+  try {
+    const len = (mobileKeyboardInput.value || '').length;
+    mobileKeyboardInput.setSelectionRange(len, len);
+  } catch (e) {}
 }
 
 function resetMobileKeyboardInput() {
   if (mobileKeyboardInput) {
     mobileKeyboardInput.value = '';
   }
+  lastMobileKeyboardValue = '';
+}
+
+function maintainMobileKeyboardFocus() {
+  if (!isMobileInputMode) return;
+  mobileKeyboardRefocusPending = true;
+  requestAnimationFrame(() => {
+    if (!mobileKeyboardRefocusPending) return;
+    focusMobileKeyboardInput();
+    mobileKeyboardRefocusPending = false;
+  });
+}
+
+function diffMobileKeyboardText(previousText, nextText) {
+  const prevLen = previousText.length;
+  const nextLen = nextText.length;
+  let prefix = 0;
+  const maxPrefix = Math.min(prevLen, nextLen);
+  while (prefix < maxPrefix && previousText.charCodeAt(prefix) === nextText.charCodeAt(prefix)) {
+    prefix++;
+  }
+  let suffix = 0;
+  const maxSuffix = Math.min(prevLen - prefix, nextLen - prefix);
+  while (
+    suffix < maxSuffix &&
+    previousText.charCodeAt(prevLen - 1 - suffix) === nextText.charCodeAt(nextLen - 1 - suffix)
+  ) {
+    suffix++;
+  }
+  const removedText = previousText.slice(prefix, prevLen - suffix);
+  const insertedText = nextText.slice(prefix, nextLen - suffix);
+  return { removedText, insertedText };
 }
 
 // --- Nav bar (Phase 3) ---
@@ -571,54 +609,50 @@ if (mobileKeyboardButton && mobileKeyboardInput) {
 
   mobileKeyboardInput.addEventListener('focus', () => {
     isMobileInputMode = true;
+    mobileKeyboardRefocusPending = false;
+    lastMobileKeyboardValue = mobileKeyboardInput.value || '';
   });
 
   mobileKeyboardInput.addEventListener('blur', () => {
-    isMobileInputMode = false;
-    resetMobileKeyboardInput();
+    setTimeout(() => {
+      if (mobileKeyboardRefocusPending) return;
+      isMobileInputMode = false;
+      resetMobileKeyboardInput();
+    }, 0);
   });
 
   mobileKeyboardInput.addEventListener('beforeinput', (e) => {
-    let keyTap = null;
-
-    if (e.inputType === 'deleteContentBackward') {
-      keyTap = ['Backspace', 'Backspace', 8];
-    } else if (e.inputType === 'deleteContentForward') {
-      keyTap = ['Delete', 'Delete', 46];
-    } else if (e.inputType === 'insertLineBreak' || e.inputType === 'insertParagraph') {
-      keyTap = ['Enter', 'Enter', 13];
+    if (e.inputType === 'insertLineBreak' || e.inputType === 'insertParagraph') {
+      e.preventDefault();
+      e.stopPropagation();
+      sendKeyTap('Enter', 'Enter', 13);
     }
-
-    if (!keyTap) return;
-
-    e.preventDefault();
-    e.stopPropagation();
-    sendKeyTap(...keyTap);
-    resetMobileKeyboardInput();
-    requestAnimationFrame(() => {
-      if (isMobileInputMode) {
-        focusMobileKeyboardInput();
-      }
-    });
   });
 
   mobileKeyboardInput.addEventListener('input', (e) => {
     if (e.isComposing) return;
-    const text = mobileKeyboardInput.value;
-    if (!text) return;
+    const previousText = lastMobileKeyboardValue;
+    const nextText = mobileKeyboardInput.value;
+    const { removedText, insertedText } = diffMobileKeyboardText(previousText, nextText);
 
-    sendInput({
-      type: 'clipboard',
-      action: 'pasteText',
-      text
-    });
-    resetMobileKeyboardInput();
-
-    requestAnimationFrame(() => {
-      if (isMobileInputMode) {
-        focusMobileKeyboardInput();
+    if (removedText.length > 0) {
+      const deleteKey = e.inputType === 'deleteContentForward'
+        ? ['Delete', 'Delete', 46]
+        : ['Backspace', 'Backspace', 8];
+      for (let i = 0; i < removedText.length; i++) {
+        sendKeyTap(...deleteKey);
       }
-    });
+    }
+
+    if (insertedText.length > 0) {
+      sendInput({
+        type: 'clipboard',
+        action: 'pasteText',
+        text: insertedText
+      });
+    }
+
+    lastMobileKeyboardValue = mobileKeyboardInput.value;
   });
 }
 
@@ -788,7 +822,11 @@ video.addEventListener('mousedown', (e) => {
   if (shouldIgnoreMouseEvent()) return;
 
   preventDefaultIfPossible(e);
-  focusVideoForInput();
+  if (isMobileInputMode) {
+    maintainMobileKeyboardFocus();
+  } else {
+    focusVideoForInput();
+  }
   dragActive = true;
   const { x, y } = mapCoords(e);
   sendInput({
@@ -861,6 +899,9 @@ video.addEventListener('touchstart', (e) => {
   }
 
   preventDefaultIfPossible(e);
+  if (isMobileInputMode) {
+    maintainMobileKeyboardFocus();
+  }
   const touch = e.touches[0];
   suppressMouseUntil = performance.now() + TOUCH_MOUSE_SUPPRESS_MS;
   activeTouchGesture = {
@@ -922,6 +963,9 @@ video.addEventListener('touchend', (e) => {
   const isTap = !activeTouchGesture.moved && Math.hypot(totalDx, totalDy) < TOUCH_TAP_MAX_DISTANCE;
 
   if (isTap) {
+    if (isMobileInputMode) {
+      maintainMobileKeyboardFocus();
+    }
     const { x, y } = mapCoords(touch);
     sendInput({
       type: 'mouse',
@@ -1051,7 +1095,11 @@ document.addEventListener('cut', (e) => {
 
 video.addEventListener('click', () => {
   if (shouldIgnoreMouseEvent()) return;
-  focusVideoForInput();
+  if (isMobileInputMode) {
+    maintainMobileKeyboardFocus();
+  } else {
+    focusVideoForInput();
+  }
 });
 video.addEventListener('loadedmetadata', () => {
   layoutVideo();

--- a/client/viewer/index.html
+++ b/client/viewer/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <title>LobsterLink</title>
   <link rel="icon"
     href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🦞</text></svg>">
@@ -15,6 +15,11 @@
   <meta name="twitter:description" content="Let a human complete blocked steps in an agent's browser, without sharing credentials.">
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
+    :root {
+      --nav-height: 40px;
+      --safe-top: env(safe-area-inset-top, 0px);
+      --header-total: calc(var(--nav-height) + var(--safe-top));
+    }
     html, body {
       height: 100%;
       background: #000;
@@ -22,15 +27,23 @@
       font-family: system-ui, sans-serif;
       overflow: hidden;
     }
+    body {
+      min-height: 100dvh;
+    }
 
     #nav-bar {
       display: flex;
       align-items: center;
       gap: 6px;
       padding: 6px 10px;
+      padding-top: calc(6px + var(--safe-top));
+      padding-left: calc(10px + env(safe-area-inset-left, 0px));
+      padding-right: calc(10px + env(safe-area-inset-right, 0px));
       background: #1a1a2e;
       border-bottom: 1px solid #333;
-      height: 40px;
+      height: var(--header-total);
+      position: relative;
+      z-index: 20;
     }
     .nav-btn {
       background: #16213e;
@@ -70,7 +83,8 @@
 
     #video-container {
       width: 100vw;
-      height: calc(100vh - 40px);
+      height: calc(100vh - var(--header-total));
+      height: calc(100dvh - var(--header-total));
       background: #000;
       position: relative;
       overflow: hidden;
@@ -113,6 +127,51 @@
 
     @media (pointer: coarse), (hover: none) {
       .mobile-only { display: flex; }
+    }
+
+    @media (max-width: 640px) {
+      #nav-bar {
+        gap: 4px;
+        padding-top: calc(4px + var(--safe-top));
+        padding-bottom: 4px;
+        padding-left: calc(6px + env(safe-area-inset-left, 0px));
+        padding-right: calc(6px + env(safe-area-inset-right, 0px));
+      }
+      #tab-select { max-width: 90px; flex-shrink: 1; min-width: 40px; }
+      #viewport-select { display: none; }
+      #connection-status {
+        width: 10px; height: 10px;
+        padding: 0; border-radius: 50%;
+        font-size: 0; overflow: hidden;
+      }
+    }
+
+    @media (max-width: 560px) {
+      #url-bar,
+      #tab-select,
+      #btn-new-tab,
+      #btn-close-tab,
+      #viewport-select {
+        display: none;
+      }
+
+      #nav-bar {
+        gap: 4px;
+        padding-top: calc(6px + var(--safe-top));
+        padding-bottom: 6px;
+        padding-left: calc(6px + env(safe-area-inset-left, 0px));
+        padding-right: calc(6px + env(safe-area-inset-right, 0px));
+      }
+
+      #btn-mobile-keyboard {
+        display: flex;
+      }
+
+      #connection-status {
+        width: 10px; height: 10px;
+        padding: 0; border-radius: 50%;
+        font-size: 0; overflow: hidden;
+      }
     }
 
     #connect-overlay {

--- a/viewer.html
+++ b/viewer.html
@@ -1,15 +1,25 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <title>LobsterLink Viewer</title>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
+    :root {
+      --nav-height: 40px;
+      --safe-top: env(safe-area-inset-top, 0px);
+      --header-total: calc(var(--nav-height) + var(--safe-top));
+    }
     html, body {
       height: 100%;
       background: #000;
       color: #e0e0e0;
       font-family: system-ui, sans-serif;
       overflow: hidden;
+    }
+    body {
+      min-height: 100dvh;
     }
 
     /* Nav is a reserved viewer area (in layout flow). It is NOT part of the
@@ -20,9 +30,14 @@
       align-items: center;
       gap: 6px;
       padding: 6px 10px;
+      padding-top: calc(6px + var(--safe-top));
+      padding-left: calc(10px + env(safe-area-inset-left, 0px));
+      padding-right: calc(10px + env(safe-area-inset-right, 0px));
       background: #1a1a2e;
       border-bottom: 1px solid #333;
-      height: 40px;
+      height: var(--header-total);
+      position: relative;
+      z-index: 20;
     }
     .nav-btn {
       background: #16213e;
@@ -62,7 +77,8 @@
 
     #video-container {
       width: 100vw;
-      height: calc(100vh - 40px);
+      height: calc(100vh - var(--header-total));
+      height: calc(100dvh - var(--header-total));
       background: #000;
       position: relative;
       overflow: hidden;
@@ -105,6 +121,34 @@
 
     @media (pointer: coarse), (hover: none) {
       .mobile-only { display: flex; }
+    }
+
+    @media (max-width: 560px) {
+      #url-bar,
+      #tab-select,
+      #btn-new-tab,
+      #btn-close-tab,
+      #viewport-select {
+        display: none;
+      }
+
+      #nav-bar {
+        gap: 4px;
+        padding-top: calc(6px + var(--safe-top));
+        padding-bottom: 6px;
+        padding-left: calc(6px + env(safe-area-inset-left, 0px));
+        padding-right: calc(6px + env(safe-area-inset-right, 0px));
+      }
+
+      #btn-mobile-keyboard {
+        display: flex;
+      }
+
+      #connection-status {
+        width: 10px; height: 10px;
+        padding: 0; border-radius: 50%;
+        font-size: 0; overflow: hidden;
+      }
     }
 
     #connect-overlay {


### PR DESCRIPTION
Reimplementation of #4 .

This fixes the mobile viewer backspace/delete path for remote form fields by making the mobile keyboard textarea stateful and preserving focus across remote taps.

It also updates both viewer entrypoints:
- `viewer.js`
- `client/viewer.js`

So the hosted viewer stays in sync with the extension viewer behavior.