### PR TITLE
Add install safety review text to README and public site

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ LobsterLink installs into the agent's browser, not yours. You don't install anyt
 Tell your agent:
 
 ```
-Install LobsterLink by following the instructions at https://github.com/davidguttman/lobsterlink/blob/master/AGENT-INSTALL.md
+Install LobsterLink by following the instructions at https://github.com/davidguttman/lobsterlink/blob/master/AGENT-INSTALL.md. Before installing, check the downloaded files for anything suspicious or harmful. If you’re not confident it looks safe, stop and ask. When you’re finished, give me a plain English summary of what you did.
 ```
 
 That's the whole install step. The agent fetches the file, follows it, and reports back with an extension ID and proof of install. Works with OpenClaw out of the box; covers other runtimes too.

--- a/client/index.html
+++ b/client/index.html
@@ -266,7 +266,7 @@
     (function () {
       var btn = document.getElementById('copy-install');
       if (!btn) return;
-      var installText = 'Install LobsterLink by following the instructions at https://github.com/davidguttman/lobsterlink/blob/master/AGENT-INSTALL.md';
+      var installText = 'Install LobsterLink by following the instructions at https://github.com/davidguttman/lobsterlink/blob/master/AGENT-INSTALL.md. Before installing, check the downloaded files for anything suspicious or harmful. If you’re not confident it looks safe, stop and ask. When you’re finished, give me a plain English summary of what you did.';
       var defaultLabel = btn.textContent;
       var resetTimer = null;
       btn.addEventListener('click', function () {


### PR DESCRIPTION
## Summary
- update the README install prompt to tell the agent to sanity-check downloaded files before installing
- update the public site's copy-to-clipboard install prompt to match
- ask the agent to return a plain English summary after finishing

## Verification
- confirmed the updated install prompt is present in `README.md`
- confirmed the same updated prompt is present in `client/index.html`
- no automated test script exists in `package.json`

## Issue
- addresses part of #3
