### PR TITLE
Host only via CDP screencast; drop tabCapture path

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,7 +1,5 @@
-// LobsterLink service worker — orchestrates host mode
-// Supports two capture modes:
-//   'tabCapture' — chrome.tabCapture (requires user gesture from popup)
-//   'screencast' — CDP Page.startScreencast (works programmatically)
+// LobsterLink service worker — orchestrates host mode.
+// Hosting uses CDP Page.startScreencast exclusively.
 
 const SCREENCAST_MAX_WIDTH = 3840;
 const SCREENCAST_MAX_HEIGHT = 2160;
@@ -15,7 +13,7 @@ const DEFAULT_HOST_STATE = {
   capturedTabId: null,
   debuggerAttached: false,
   viewerConnected: false,
-  captureMode: null, // 'tabCapture' | 'screencast'
+  captureMode: null, // 'screencast' when hosting
   screencastWidth: null,
   screencastHeight: null,
   pageAgentReady: false,
@@ -312,16 +310,7 @@ async function sendPageAgentInput(tabId, evt, attempt = 0) {
 // --- Message handling ---
 
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
-  if (msg.action === 'startHosting') {
-    ensureHostStateLoaded().then(() => handleStartHosting()).then(sendResponse);
-    return true;
-  }
-  if (msg.action === 'startHostingWithStreamId') {
-    ensureHostStateLoaded().then(() => handleStartHostingWithStreamId(msg.tabId, msg.streamId)).then(sendResponse);
-    return true;
-  }
   if (msg.action === 'startHostingCDP') {
-    // Explicit CDP screencast mode (for programmatic/agent use)
     ensureHostStateLoaded().then(() => handleStartHostingCDP(msg.tabId)).then(sendResponse);
     return true;
   }
@@ -404,13 +393,9 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     ensureHostStateLoaded().then(async () => {
       hostState.viewerConnected = true;
       await persistHostState();
-      log('[LOBSTERLINK:bg] Viewer connected, mode:', hostState.captureMode);
+      log('[LOBSTERLINK:bg] Viewer connected');
       logDiagnostic('viewer_connected', { mode: hostState.captureMode });
-      // In screencast mode, debugger is already attached (needed for screencast).
-      // In tabCapture mode, ensure the page agent is ready for DOM-driven control.
-      if (hostState.captureMode === 'tabCapture') {
-        await ensurePageAgent(hostState.capturedTabId);
-      } else if (hostState.captureMode === 'screencast' && hostState.debuggerAttached) {
+      if (hostState.debuggerAttached) {
         // Restart screencast to force CDP to emit fresh frames.
         // CDP only sends frames on visual changes, so on a static page
         // frames may have arrived before the viewer connected.
@@ -578,94 +563,6 @@ async function resetTabZoom(tabId) {
   }
 }
 
-// --- Host lifecycle: tabCapture mode ---
-
-async function startTabCaptureMode(tabId, streamId) {
-  hostState.capturedTabId = tabId;
-  resetPageAgentState();
-
-  await ensureWindowVisible(tabId);
-  await resetTabZoom(tabId);
-  await ensureOffscreenDocument();
-  await chrome.runtime.sendMessage({
-    action: 'offscreen:startHost',
-    streamId,
-    tabId
-  });
-
-  const peerId = await waitForPeerId();
-  hostState.hosting = true;
-  hostState.peerId = peerId;
-  hostState.captureMode = 'tabCapture';
-  hostState.screencastWidth = null;
-  hostState.screencastHeight = null;
-  setupTabListeners();
-  await persistHostState();
-  await ensurePageAgent(tabId);
-  await sendHostOverlay(tabId, peerId);
-  await activateTabWindow(tabId);
-
-  log('[LOBSTERLINK:bg] Host started (tabCapture), peerId:', peerId);
-  return { peerId, captureMode: 'tabCapture' };
-}
-
-async function handleStartHosting() {
-  try {
-    const tab = await findCapturableTab();
-    if (!tab) {
-      logDiagnostic('start_host_blocked', {
-        error: 'No capturable tab found (switch to a normal web tab and retry)'
-      });
-      return { error: 'No capturable tab found (switch to a normal web tab and retry)' };
-    }
-
-    log('[LOBSTERLINK:bg] Starting host on tab', tab.id, tab.url);
-    hostState.capturedTabId = tab.id;
-    await ensureWindowVisible(tab.id);
-
-    // Try tabCapture first (requires user gesture)
-    try {
-      const streamId = await chrome.tabCapture.getMediaStreamId({ targetTabId: tab.id });
-      return await startTabCaptureMode(tab.id, streamId);
-    } catch (tabCaptureErr) {
-      warn('[LOBSTERLINK:bg] tabCapture failed, falling back to CDP screencast:', tabCaptureErr.message);
-      return await startScreencastMode(tab.id);
-    }
-  } catch (err) {
-    error('[LOBSTERLINK:bg] startHosting error:', err);
-    logDiagnostic('start_host_error', { error: err.message || String(err) });
-    return { error: err.message };
-  }
-}
-
-async function handleStartHostingWithStreamId(tabId, streamId) {
-  try {
-    if (!tabId || !streamId) {
-      logDiagnostic('start_host_missing_stream', {
-        error: 'Missing tabCapture stream ID',
-        tabId: tabId || null
-      });
-      return { error: 'Missing tabCapture stream ID' };
-    }
-
-    const tab = await chrome.tabs.get(tabId);
-    if (isForbiddenTab(tab)) {
-      logDiagnostic('start_host_forbidden_tab', {
-        error: 'Cannot capture extension/chrome pages (switch to a normal web tab)',
-        tabId
-      });
-      return { error: 'Cannot capture extension/chrome pages (switch to a normal web tab)' };
-    }
-
-    log('[LOBSTERLINK:bg] Starting host (popup tabCapture) on tab', tabId);
-    return await startTabCaptureMode(tabId, streamId);
-  } catch (err) {
-    error('[LOBSTERLINK:bg] startHostingWithStreamId error:', err);
-    logDiagnostic('start_host_stream_error', { error: err.message || String(err), tabId });
-    return { error: err.message };
-  }
-}
-
 // --- Host lifecycle: CDP screencast mode ---
 
 async function handleStartHostingCDP(tabId) {
@@ -690,7 +587,7 @@ async function handleStartHostingCDP(tabId) {
         return { error: 'Cannot capture extension/chrome pages (switch to a normal web tab)' };
       }
     }
-    log('[LOBSTERLINK:bg] Starting host (explicit CDP mode) on tab', tabId);
+    log('[LOBSTERLINK:bg] Starting host (CDP screencast) on tab', tabId);
     return await startScreencastMode(tabId);
   } catch (err) {
     error('[LOBSTERLINK:bg] startHostingCDP error:', err);
@@ -774,7 +671,7 @@ async function stopScreencast() {
   }
 }
 
-// --- Stop hosting (both modes) ---
+// --- Stop hosting ---
 
 async function handleStopHosting() {
   teardownTabListeners();
@@ -783,16 +680,14 @@ async function handleStopHosting() {
     await sendHostOverlay(hostState.capturedTabId, null);
   }
 
-  if (hostState.captureMode === 'screencast') {
-    await stopScreencast();
-    // Restore original viewport
-    if (hostState.capturedTabId && hostState.debuggerAttached) {
-      try {
-        await chrome.debugger.sendCommand(
-          { tabId: hostState.capturedTabId }, 'Emulation.clearDeviceMetricsOverride'
-        );
-      } catch (e) { /* tab may be gone */ }
-    }
+  await stopScreencast();
+  // Restore original viewport
+  if (hostState.capturedTabId && hostState.debuggerAttached) {
+    try {
+      await chrome.debugger.sendCommand(
+        { tabId: hostState.capturedTabId }, 'Emulation.clearDeviceMetricsOverride'
+      );
+    } catch (e) { /* tab may be gone */ }
   }
 
   try {
@@ -1049,9 +944,7 @@ function onTabRemoved(tabId) {
     wasCaptured: tabId === hostState.capturedTabId
   });
   if (tabId === hostState.capturedTabId) {
-    if (hostState.captureMode === 'screencast') {
-      stopScreencast();
-    }
+    stopScreencast();
     hostState.capturedTabId = null;
     hostState.debuggerAttached = false;
     resetPageAgentState();
@@ -1183,7 +1076,6 @@ async function handleControlEvent(evt) {
 
 async function setHostViewport(width, height) {
   if (!hostState.capturedTabId || !hostState.debuggerAttached) return;
-  if (hostState.captureMode !== 'screencast') return;
 
   const tabId = hostState.capturedTabId;
   log('[LOBSTERLINK:bg] Setting host viewport to', width, 'x', height);
@@ -1268,56 +1160,38 @@ async function switchTab(tabId) {
     return;
   }
 
-  if (hostState.captureMode === 'screencast') {
-    // Stop screencast on old tab
-    await stopScreencast();
-    await detachDebugger(hostState.capturedTabId);
-    resetPageAgentState();
+  // Stop screencast on old tab
+  await stopScreencast();
+  await detachDebugger(hostState.capturedTabId);
+  resetPageAgentState();
 
-    // Activate and capture new tab
-    await activateTabWindow(tabId);
-    await resetTabZoom(tabId);
-    hostState.capturedTabId = tabId;
+  // Activate and capture new tab
+  await activateTabWindow(tabId);
+  await resetTabZoom(tabId);
+  hostState.capturedTabId = tabId;
 
-    await attachDebugger(tabId);
+  await attachDebugger(tabId);
 
-    // Get new page dimensions
-    const { width, height } = await getCurrentViewport(tabId);
-    const devicePixelRatio = await getPageDevicePixelRatio(tabId);
-    const capture = getCaptureSize(width, height, devicePixelRatio);
-    hostState.screencastWidth = width;
-    hostState.screencastHeight = height;
-    hostState.pageDevicePixelRatio = devicePixelRatio;
+  // Get new page dimensions
+  const { width, height } = await getCurrentViewport(tabId);
+  const devicePixelRatio = await getPageDevicePixelRatio(tabId);
+  const capture = getCaptureSize(width, height, devicePixelRatio);
+  hostState.screencastWidth = width;
+  hostState.screencastHeight = height;
+  hostState.pageDevicePixelRatio = devicePixelRatio;
 
-    // Resize canvas in offscreen doc
-    await chrome.runtime.sendMessage({
-      action: 'offscreen:screencastResize',
-      width: capture.width,
-      height: capture.height,
-      viewportWidth: width,
-      viewportHeight: height
-    });
+  // Resize canvas in offscreen doc
+  await chrome.runtime.sendMessage({
+    action: 'offscreen:screencastResize',
+    width: capture.width,
+    height: capture.height,
+    viewportWidth: width,
+    viewportHeight: height
+  });
 
-    // Restart screencast on new tab
-    await restartScreencast(tabId, capture.width, capture.height);
-    await ensurePageAgent(tabId);
-  } else {
-    // tabCapture mode
-    resetPageAgentState();
-    await activateTabWindow(tabId);
-    await ensureWindowVisible(tabId);
-    await resetTabZoom(tabId);
-
-    const streamId = await chrome.tabCapture.getMediaStreamId({ targetTabId: tabId });
-    hostState.capturedTabId = tabId;
-
-    await chrome.runtime.sendMessage({
-      action: 'offscreen:switchStream',
-      streamId,
-      tabId
-    });
-    await ensurePageAgent(tabId);
-  }
+  // Restart screencast on new tab
+  await restartScreencast(tabId, capture.width, capture.height);
+  await ensurePageAgent(tabId);
 
   const tab = await chrome.tabs.get(tabId);
   await persistHostState();
@@ -1462,22 +1336,19 @@ async function retryAttachDebugger(maxRetries, delayMs) {
       if (tab) {
         const attached = await attachDebugger(tab.id);
         if (hostState.debuggerAttached) {
-          // If in screencast mode, restart the screencast
-          if (hostState.captureMode === 'screencast') {
-            const { width, height } = await getCurrentViewport(tab.id);
-            const devicePixelRatio = hostState.pageDevicePixelRatio || await getPageDevicePixelRatio(tab.id);
-            const capture = getCaptureSize(width, height, devicePixelRatio);
-            hostState.screencastWidth = width;
-            hostState.screencastHeight = height;
-            hostState.pageDevicePixelRatio = devicePixelRatio;
-            await chrome.debugger.sendCommand({ tabId: tab.id }, 'Page.enable');
-            await chrome.debugger.sendCommand({ tabId: tab.id }, 'Page.startScreencast', {
-              format: 'jpeg',
-              quality: SCREENCAST_JPEG_QUALITY,
-              maxWidth: capture.width,
-              maxHeight: capture.height
-            });
-          }
+          const { width, height } = await getCurrentViewport(tab.id);
+          const devicePixelRatio = hostState.pageDevicePixelRatio || await getPageDevicePixelRatio(tab.id);
+          const capture = getCaptureSize(width, height, devicePixelRatio);
+          hostState.screencastWidth = width;
+          hostState.screencastHeight = height;
+          hostState.pageDevicePixelRatio = devicePixelRatio;
+          await chrome.debugger.sendCommand({ tabId: tab.id }, 'Page.enable');
+          await chrome.debugger.sendCommand({ tabId: tab.id }, 'Page.startScreencast', {
+            format: 'jpeg',
+            quality: SCREENCAST_JPEG_QUALITY,
+            maxWidth: capture.width,
+            maxHeight: capture.height
+          });
           log('[LOBSTERLINK:bg] Reattach succeeded on attempt', i + 1);
           logDiagnostic('debugger_reattach_success', { attempt: i + 1, tabId: tab.id });
           break;
@@ -1781,7 +1652,7 @@ async function handleInputEvent(evt) {
   }
 
   // Routing policy (raw-input primary):
-  //   screencast + debugger  → raw CDP Input.dispatch{Mouse,Key}Event for mouse/key.
+  //   debugger attached      → raw CDP Input.dispatch{Mouse,Key}Event for mouse/key.
   //                            This is browser-level input and is the only path that
   //                            reliably reaches cross-origin iframes (reCAPTCHA,
   //                            LinkedIn challenge frames, payment iframes, etc.).
@@ -1789,14 +1660,11 @@ async function handleInputEvent(evt) {
   //                            cannot cross those boundaries and silently no-ops.
   //   clipboard              → page-agent (DOM access for selection text / text
   //                            insertion into editables; no CDP equivalent here).
-  //   tabCapture or no CDP   → page-agent is the only option; fall through to it.
-  const canUseCdp = hostState.captureMode === 'screencast' && hostState.debuggerAttached;
-
-  if (canUseCdp && evt.type === 'mouse') {
+  if (hostState.debuggerAttached && evt.type === 'mouse') {
     dispatchMouseEvent(tabId, evt);
     return;
   }
-  if (canUseCdp && evt.type === 'key') {
+  if (hostState.debuggerAttached && evt.type === 'key') {
     dispatchKeyEvent(tabId, evt);
     return;
   }
@@ -1815,22 +1683,8 @@ async function handleInputEvent(evt) {
     return;
   }
 
-  if (hostState.captureMode === 'tabCapture') {
-    try {
-      await routeInputToPageAgent(tabId, evt);
-    } catch (err) {
-      logDiagnostic('page_agent_route_failure', {
-        tabId,
-        type: evt.type,
-        action: evt.action,
-        error: err.message || String(err)
-      });
-    }
-    return;
-  }
-
-  // Screencast mode but debugger is detached — drop event and kick off recovery
-  // rather than silently falling back to synthetic DOM events.
+  // Debugger is detached — drop event and kick off recovery rather than
+  // silently falling back to synthetic DOM events.
   if (!reattachInProgress) {
     warn('[LOBSTERLINK:bg] Input dropped: debugger not attached, triggering reattach');
     logDiagnostic('input_dropped_debugger_missing', {
@@ -1966,5 +1820,4 @@ function dispatchKeyEvent(tabId, evt) {
 }
 
 // Expose for programmatic CDP triggering
-self.handleStartHosting = handleStartHosting;
 self.handleStartHostingCDP = handleStartHostingCDP;

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,9 @@
 {
   "manifest_version": 3,
   "name": "LobsterLink",
-  "version": "4.17.0.2",
+  "version": "4.20.0.1",
   "description": "Remote browser tab viewing and control via WebRTC",
   "permissions": [
-    "tabCapture",
     "tabs",
     "debugger",
     "activeTab",

--- a/offscreen.js
+++ b/offscreen.js
@@ -1,7 +1,5 @@
-// Offscreen document — holds PeerJS peer + MediaStream for host mode
-// Supports two modes:
-//   tabCapture — MediaStream from chrome.tabCapture via getUserMedia
-//   screencast — MediaStream from a canvas fed by CDP screencast JPEG frames
+// Offscreen document — holds PeerJS peer + MediaStream for host mode.
+// MediaStream is sourced from a canvas fed by CDP screencast JPEG frames.
 
 let peer = null;
 let mediaStream = null;
@@ -25,7 +23,6 @@ let screencastCtx = null;
 let lastFrameData = null; // stores last base64 JPEG for redraw on viewer connect
 let frameTickerInterval = null;
 let frameTickerFlip = false;
-let hostMode = null; // 'tabCapture' | 'screencast'
 let screencastViewport = { width: 1920, height: 1080 };
 
 const INPUT_TYPES = new Set(['mouse', 'key', 'clipboard']);
@@ -66,14 +63,7 @@ async function tuneCurrentVideoSender() {
 }
 
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
-  if (msg.action === 'offscreen:startHost') {
-    hostMode = 'tabCapture';
-    startHostTabCapture(msg.streamId, msg.tabId);
-    sendResponse({ ok: true });
-    return false;
-  }
   if (msg.action === 'offscreen:startHostScreencast') {
-    hostMode = 'screencast';
     startHostScreencast(msg.width, msg.height, msg.viewportWidth, msg.viewportHeight);
     sendResponse({ ok: true });
     return false;
@@ -98,11 +88,6 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     sendResponse({ ok: true });
     return false;
   }
-  if (msg.action === 'offscreen:switchStream') {
-    switchStream(msg.streamId, msg.tabId);
-    sendResponse({ ok: true });
-    return false;
-  }
   return false;
 });
 
@@ -118,7 +103,7 @@ function sendToViewer(message) {
   }
 }
 
-// --- Shared PeerJS setup (used by both modes) ---
+// --- PeerJS setup ---
 
 function setupPeer() {
   peer = new Peer();
@@ -138,20 +123,18 @@ function setupPeer() {
       tuneCurrentVideoSender().catch(() => {});
     }, 0);
 
-    // In screencast mode, redraw the last frame and start a ticker
-    // to force continuous canvas invalidation so captureStream(15)
-    // emits encoded keyframes even on static pages
-    if (hostMode === 'screencast') {
-      if (lastFrameData && screencastCtx) {
-        log('[LOBSTERLINK:offscreen] Redrawing last stored frame for new viewer');
-        const img = new Image();
-        img.onload = () => {
-          screencastCtx.drawImage(img, 0, 0, screencastCanvas.width, screencastCanvas.height);
-        };
-        img.src = 'data:image/jpeg;base64,' + lastFrameData;
-      }
-      startFrameTicker();
+    // Redraw the last frame and start a ticker to force continuous canvas
+    // invalidation so captureStream(15) emits encoded keyframes even on
+    // static pages.
+    if (lastFrameData && screencastCtx) {
+      log('[LOBSTERLINK:offscreen] Redrawing last stored frame for new viewer');
+      const img = new Image();
+      img.onload = () => {
+        screencastCtx.drawImage(img, 0, 0, screencastCanvas.width, screencastCanvas.height);
+      };
+      img.src = 'data:image/jpeg;base64,' + lastFrameData;
     }
+    startFrameTicker();
 
     call.on('close', () => {
       log('[LOBSTERLINK:offscreen] Media call closed');
@@ -170,7 +153,7 @@ function setupPeer() {
 
     conn.on('open', () => {
       log('[LOBSTERLINK:offscreen] Data channel open, notifying background');
-      sendToViewer({ type: 'hostMode', mode: hostMode });
+      sendToViewer({ type: 'hostMode', mode: 'screencast' });
       sendViewportInfo();
       // Notify background AFTER channel is open so sendToViewer works immediately
       chrome.runtime.sendMessage({ action: 'viewerConnected' });
@@ -215,80 +198,15 @@ function setupPeer() {
 }
 
 function sendViewportInfo() {
-  if (hostMode === 'tabCapture') {
-    const track = mediaStream ? mediaStream.getVideoTracks()[0] : null;
-    if (track) {
-      const settings = track.getSettings();
-      log('[LOBSTERLINK:offscreen] Sending viewport:', settings.width, 'x', settings.height);
-      sendToViewer({ type: 'viewport', width: settings.width, height: settings.height });
-    }
-  } else if (hostMode === 'screencast' && screencastCanvas) {
-    log('[LOBSTERLINK:offscreen] Sending viewport:',
-      screencastViewport.width, 'x', screencastViewport.height,
-      '| canvas:', screencastCanvas.width, 'x', screencastCanvas.height);
-    sendToViewer({
-      type: 'viewport',
-      width: screencastViewport.width,
-      height: screencastViewport.height
-    });
-  }
-}
-
-// --- tabCapture mode ---
-
-async function startHostTabCapture(streamId, tabId) {
-  try {
-    log('[LOBSTERLINK:offscreen] Starting host (tabCapture), streamId:', streamId);
-
-    mediaStream = await navigator.mediaDevices.getUserMedia({
-      audio: false,
-      video: {
-        mandatory: {
-          chromeMediaSource: 'tab',
-          chromeMediaSourceId: streamId
-        }
-      }
-    });
-
-    configureOutgoingTrack(mediaStream.getVideoTracks()[0]);
-    log('[LOBSTERLINK:offscreen] Got MediaStream, tracks:', mediaStream.getTracks().length);
-    setupPeer();
-  } catch (err) {
-    error('[LOBSTERLINK:offscreen] Failed to start host (tabCapture):', err);
-  }
-}
-
-async function switchStream(streamId, tabId) {
-  log('[LOBSTERLINK:offscreen] Switching stream, tabId:', tabId);
-
-  const newStream = await navigator.mediaDevices.getUserMedia({
-    audio: false,
-    video: {
-      mandatory: {
-        chromeMediaSource: 'tab',
-        chromeMediaSourceId: streamId
-      }
-    }
+  if (!screencastCanvas) return;
+  log('[LOBSTERLINK:offscreen] Sending viewport:',
+    screencastViewport.width, 'x', screencastViewport.height,
+    '| canvas:', screencastCanvas.width, 'x', screencastCanvas.height);
+  sendToViewer({
+    type: 'viewport',
+    width: screencastViewport.width,
+    height: screencastViewport.height
   });
-
-  if (mediaStream) {
-    mediaStream.getTracks().forEach(t => t.stop());
-  }
-  mediaStream = newStream;
-
-  if (currentCall && currentCall.peerConnection) {
-    const newTrack = newStream.getVideoTracks()[0];
-    configureOutgoingTrack(newTrack);
-    const senders = currentCall.peerConnection.getSenders();
-    const videoSender = senders.find(s => s.track && s.track.kind === 'video');
-    if (videoSender) {
-      await videoSender.replaceTrack(newTrack);
-      await tuneCurrentVideoSender();
-      log('[LOBSTERLINK:offscreen] Replaced video track on RTC connection');
-    }
-  }
-
-  sendViewportInfo();
 }
 
 // --- Screencast canvas mode ---
@@ -400,7 +318,7 @@ function stopFrameTicker() {
 
 function stopHost() {
   stopFrameTicker();
-  log('[LOBSTERLINK:offscreen] Stopping host, mode:', hostMode);
+  log('[LOBSTERLINK:offscreen] Stopping host');
   if (dataConnection) {
     dataConnection.close();
     dataConnection = null;
@@ -421,5 +339,4 @@ function stopHost() {
   screencastCtx = null;
   screencastViewport = { width: 1920, height: 1080 };
   lastFrameData = null;
-  hostMode = null;
 }

--- a/openclaw/lobsterlink-tab-share/SKILL.md
+++ b/openclaw/lobsterlink-tab-share/SKILL.md
@@ -27,7 +27,6 @@ If LobsterLink is not installed yet, follow the install instructions in this rep
 - Use the isolated `openclaw` browser profile, not the human `user` profile, unless explicitly asked otherwise.
 - When using the OpenClaw `browser` tool for this workflow, target the isolated profile explicitly: `profile="openclaw"` (normally with `target="host"`). Do not use `profile="user"` for LobsterLink hosting or inspection unless the human explicitly asks for the human browser.
 - Prefer the bridge path, not the popup click path.
-- Do not rely on popup `tabCapture` for agent automation. Chrome user gesture rules make that unreliable.
 - Verify bridge state before claiming success.
 - After hosting starts, the hosted tab MUST be the active tab in its window. This is required, not optional — CDP screencast stalls when the hosted tab is backgrounded and the viewer goes black. `Start Host` auto-focuses the hosted tab; keep it frontmost and re-focus with **Show Hosted Tab** if it drops.
 - The bridge page is the source of truth for the peer ID and viewer URL. Read them from the bridge's `Current Peer ID` and `Viewer URL` fields, not from any overlay on the hosted tab. Host state is persisted by the extension, so if `Start Host` leaves the bridge in the background you can reopen `BRIDGE_URL` — the fields will still show the current session.

--- a/popup.js
+++ b/popup.js
@@ -40,23 +40,18 @@ hostStart.addEventListener('click', async () => {
   hostStatus.textContent = 'Starting...';
   hostStatus.className = 'status';
 
-  let response;
-  try {
-    const [activeTab] = await chrome.tabs.query({ active: true, currentWindow: true });
-    if (activeTab && !isForbiddenTab(activeTab)) {
-      const streamId = await chrome.tabCapture.getMediaStreamId({ targetTabId: activeTab.id });
-      response = await chrome.runtime.sendMessage({
-        action: 'startHostingWithStreamId',
-        streamId,
-        tabId: activeTab.id
-      });
-    } else {
-      response = await chrome.runtime.sendMessage({ action: 'startHosting' });
-    }
-  } catch (err) {
-    console.warn('[LOBSTERLINK:popup] Direct tabCapture start failed, falling back:', err);
-    response = await chrome.runtime.sendMessage({ action: 'startHosting' });
+  const [activeTab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  if (!activeTab || isForbiddenTab(activeTab)) {
+    hostStatus.textContent = 'Switch to a normal web tab and retry';
+    hostStatus.className = 'status error';
+    hostStart.disabled = false;
+    return;
   }
+
+  const response = await chrome.runtime.sendMessage({
+    action: 'startHostingCDP',
+    tabId: activeTab.id
+  });
 
   if (response.error) {
     hostStatus.textContent = response.error;
@@ -69,8 +64,7 @@ hostStart.addEventListener('click', async () => {
   hostPeerId.style.display = 'block';
   hostStart.style.display = 'none';
   hostStop.style.display = 'inline-block';
-  const modeLabel = response.captureMode === 'screencast' ? ' (CDP screencast)' : '';
-  hostStatus.textContent = 'Hosting' + modeLabel + ' — share the peer ID with the viewer';
+  hostStatus.textContent = 'Hosting — share the peer ID with the viewer';
   hostStatus.className = 'status ok';
 });
 


### PR DESCRIPTION
## Summary
- make popup hosting go directly through the CDP screencast path
- remove the tabCapture product flow and drop the tabCapture permission
- keep the existing screencast viewport-follow behavior intact while bumping the extension version to 4.20.0.1

## Verification Evidence
- Fresh syntax verification passed: `node -c popup.js && node -c background.js && node -c offscreen.js`
- Scope check passed: branch was rebased so this PR is a single commit on top of `master`
- Runtime smoke test has **not** been run yet on this host because LobsterLink is not currently installed in the isolated `openclaw` browser

## Test Plan
- [ ] Start hosting from the popup on a normal web tab and confirm it uses screencast
- [ ] Connect a viewer and confirm the host stays active/frontmost and continues streaming
- [ ] Resize the viewer and confirm viewport-follow still resizes the host
- [ ] Confirm Chrome no longer requests the `tabCapture` permission