### PR TITLE
Add configurable self-hosted signaling and custom viewer URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,28 @@ This repo ships with a skill at `openclaw/lobsterlink-tab-share/SKILL.md`. It op
 ### Public web viewer
 
 The `client/` directory is the standalone static viewer entrypoint that powers `lobsterl.ink`. `client/viewer.js` is the shared viewer logic used by both the extension and hosted client; see `client/README.md` for the file layout.
+
+### Self-hosted signaling and viewer
+
+By default LobsterLink uses the public `0.peerjs.com` signaling server and the public `https://lobsterl.ink/` viewer. Both are configurable per install — the extension's settings live in `chrome.storage.local` and can be edited from the **Signaling Settings** page (right-click the extension icon → "Options", or the Signaling Settings button in the popup).
+
+```
+viewerUrlBase   https://lobsterl.ink/      // e.g. http://vier:9000/
+peerJsHost      0.peerjs.com               // e.g. vier
+peerJsPort      443                        // e.g. 9001
+peerJsPath      /                          // e.g. /peerjs
+peerJsSecure    true                       // false for plain-HTTP signaling
+```
+
+The viewer URL that the extension hands back is generated from these settings, and signaling params that differ from the defaults are embedded as query params so the viewer page connects to the same PeerJS server as the host. The hosted `client/` site parses those same query params, so a link like `http://vier:9000/?host=<id>&peerJsHost=vier&peerJsPort=9001&peerJsSecure=false` connects to a self-hosted PeerJS server over the Tailscale network — both the signaling server and the viewer URL stay inside your VPN.
+
+To stand up your own signaling server and viewer:
+
+```bash
+npm install -g peer
+peerjs --port 9001 --path /
+# serve client/ over http(s) from any static file server on the same network
+python3 -m http.server --directory client 9000
+```
+
+Then open the extension's Signaling Settings, fill in the matching values, and start hosting as usual.

--- a/background.js
+++ b/background.js
@@ -1,6 +1,7 @@
 // LobsterLink service worker — orchestrates host mode.
 // Hosting uses CDP Page.startScreencast exclusively.
 
+importScripts('lib/signaling-config.js');
 importScripts('lib/background-utils.js');
 
 const SCREENCAST_JPEG_QUALITY = 92;
@@ -44,14 +45,31 @@ let tabListenersInstalled = false;
 let recentDiagnostics = [];
 let lastDiagnosticError = null;
 let remoteLoggingEnabled = false;
+let signalingConfig = normalizeSignalingConfig({});
 
-// Load opt-in remote logging flag from storage (default: off)
-chrome.storage.local.get({ lobsterlinkDebugLoggingEnabled: false }, (result) => {
-  remoteLoggingEnabled = !!result.lobsterlinkDebugLoggingEnabled;
-});
+// Load opt-in remote logging flag + signaling config from storage
+chrome.storage.local.get(
+  { lobsterlinkDebugLoggingEnabled: false, ...DEFAULT_SIGNALING_CONFIG },
+  (result) => {
+    remoteLoggingEnabled = !!result.lobsterlinkDebugLoggingEnabled;
+    signalingConfig = normalizeSignalingConfig(result);
+  }
+);
 chrome.storage.onChanged.addListener((changes, area) => {
-  if (area === 'local' && changes.lobsterlinkDebugLoggingEnabled) {
+  if (area !== 'local') return;
+  if (changes.lobsterlinkDebugLoggingEnabled) {
     remoteLoggingEnabled = !!changes.lobsterlinkDebugLoggingEnabled.newValue;
+  }
+  let signalingChanged = false;
+  const next = { ...signalingConfig };
+  for (const key of SIGNALING_STORAGE_KEYS) {
+    if (changes[key]) {
+      next[key] = changes[key].newValue;
+      signalingChanged = true;
+    }
+  }
+  if (signalingChanged) {
+    signalingConfig = normalizeSignalingConfig(next);
   }
 });
 
@@ -161,7 +179,7 @@ function logDiagnostic(event, details = {}) {
 
 function getViewerUrl(peerId) {
   if (!peerId) return null;
-  return `https://lobsterl.ink/?host=${encodeURIComponent(peerId)}`;
+  return buildViewerUrl(peerId, signalingConfig);
 }
 
 function getStatusPayload() {
@@ -630,7 +648,8 @@ async function startScreencastMode(tabId) {
     width: capture.width,
     height: capture.height,
     viewportWidth: width,
-    viewportHeight: height
+    viewportHeight: height,
+    signalingConfig
   });
 
   // Enable Page domain events (required for screencastFrame events to fire)

--- a/bridge.html
+++ b/bridge.html
@@ -621,6 +621,7 @@
     </main>
   </div>
 
+  <script src="lib/signaling-config.js"></script>
   <script src="lib/bridge-utils.js"></script>
   <script src="bridge.js"></script>
 </body>

--- a/bridge.js
+++ b/bridge.js
@@ -41,8 +41,29 @@ const state = {
   backgroundLastError: null,
   bridgeLastError: null,
   refreshInFlight: false,
-  refreshQueued: false
+  refreshQueued: false,
+  signalingConfig: normalizeSignalingConfig({})
 };
+
+chrome.storage.local.get(DEFAULT_SIGNALING_CONFIG, (result) => {
+  state.signalingConfig = normalizeSignalingConfig(result);
+  renderStatus();
+});
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area !== 'local') return;
+  let signalingChanged = false;
+  const next = { ...state.signalingConfig };
+  for (const key of SIGNALING_STORAGE_KEYS) {
+    if (changes[key]) {
+      next[key] = changes[key].newValue;
+      signalingChanged = true;
+    }
+  }
+  if (signalingChanged) {
+    state.signalingConfig = normalizeSignalingConfig(next);
+    renderStatus();
+  }
+});
 
 const REFRESH_INTERVAL_MS = 1500;
 const MAX_BRIDGE_LOGS = 80;
@@ -160,7 +181,7 @@ function renderStatus() {
 
   const requestedViewerPeerId = statusEls.viewerPeerId.value.trim();
   statusEls.viewerUrl.textContent = status.viewerUrl ||
-    (requestedViewerPeerId ? buildViewerUrl(requestedViewerPeerId) : 'No active host viewer URL');
+    (requestedViewerPeerId ? buildViewerUrl(requestedViewerPeerId, state.signalingConfig) : 'No active host viewer URL');
   statusEls.tabContext.textContent = capturedTab
     ? [
         `tabId=${capturedTab.id}`,
@@ -461,7 +482,7 @@ async function openViewerForPeer(peerId) {
     throw new Error('Peer ID is required to open the viewer.');
   }
   await chrome.tabs.create({
-    url: buildViewerUrl(peerId)
+    url: buildViewerUrl(peerId, state.signalingConfig)
   });
   setHostMessage(`Opened viewer for ${peerId}.`, 'ok');
 }
@@ -497,7 +518,7 @@ function bindControls() {
   statusEls.viewerPeerId.addEventListener('input', () => {
     const peerId = statusEls.viewerPeerId.value.trim();
     statusEls.viewerUrl.textContent = peerId
-      ? buildViewerUrl(peerId)
+      ? buildViewerUrl(peerId, state.signalingConfig)
       : (state.status?.viewerUrl || 'No active host viewer URL');
   });
 

--- a/client/README.md
+++ b/client/README.md
@@ -32,3 +32,17 @@ https://lobsterl.ink/?host=<host-peer-id>
 
 The page connects to the LobsterLink host over WebRTC via PeerJS and renders the shared
 tab with remote input forwarded back.
+
+## Self-hosted signaling
+
+If the LobsterLink extension is configured to use a self-hosted PeerJS server (see the
+main `README.md`), it embeds the signaling details in the viewer URL as query params:
+
+```
+https://vier:9000/?host=<id>&peerJsHost=vier&peerJsPort=9001&peerJsSecure=false
+```
+
+`client/viewer.js` parses these params (`peerJsHost`, `peerJsPort`, `peerJsPath`,
+`peerJsSecure`) via `lib/signaling-config.js` and passes them to the PeerJS client.
+Missing params fall back to the public defaults, so existing `lobsterl.ink/?host=...`
+links keep working unchanged.

--- a/client/lib/signaling-config.js
+++ b/client/lib/signaling-config.js
@@ -1,0 +1,138 @@
+'use strict';
+
+// LobsterLink signaling-config helper.
+// Shared across the service worker (importScripts), the offscreen document,
+// the bridge page, the options page, and the viewer client — plus Vitest.
+// Defines normalization, URL-param round-tripping, and viewer URL building
+// so host/viewer stay aligned when pointed at self-hosted infrastructure.
+
+const DEFAULT_SIGNALING_CONFIG = {
+  viewerUrlBase: 'https://lobsterl.ink/',
+  peerJsHost: '0.peerjs.com',
+  peerJsPort: 443,
+  peerJsPath: '/',
+  peerJsSecure: true
+};
+
+const SIGNALING_STORAGE_KEYS = Object.freeze([
+  'viewerUrlBase',
+  'peerJsHost',
+  'peerJsPort',
+  'peerJsPath',
+  'peerJsSecure'
+]);
+
+function coerceString(value, fallback) {
+  if (typeof value !== 'string') return fallback;
+  const trimmed = value.trim();
+  return trimmed === '' ? fallback : trimmed;
+}
+
+function coercePort(value, fallback) {
+  if (value === null || value === undefined || value === '') return fallback;
+  const n = Number(value);
+  if (!Number.isFinite(n)) return fallback;
+  const int = Math.trunc(n);
+  if (int < 1 || int > 65535) return fallback;
+  return int;
+}
+
+function coerceBool(value, fallback) {
+  if (typeof value === 'boolean') return value;
+  if (value === 'true' || value === '1' || value === 1) return true;
+  if (value === 'false' || value === '0' || value === 0) return false;
+  return fallback;
+}
+
+function coercePath(value, fallback) {
+  if (typeof value !== 'string') return fallback;
+  const trimmed = value.trim();
+  if (trimmed === '') return fallback;
+  return trimmed.startsWith('/') ? trimmed : '/' + trimmed;
+}
+
+function coerceViewerUrlBase(value, fallback) {
+  const str = coerceString(value, null);
+  if (!str) return fallback;
+  try {
+    const parsed = new URL(str);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return fallback;
+    return str;
+  } catch (e) {
+    return fallback;
+  }
+}
+
+function normalizeSignalingConfig(input) {
+  const src = input || {};
+  return {
+    viewerUrlBase: coerceViewerUrlBase(src.viewerUrlBase, DEFAULT_SIGNALING_CONFIG.viewerUrlBase),
+    peerJsHost: coerceString(src.peerJsHost, DEFAULT_SIGNALING_CONFIG.peerJsHost),
+    peerJsPort: coercePort(src.peerJsPort, DEFAULT_SIGNALING_CONFIG.peerJsPort),
+    peerJsPath: coercePath(src.peerJsPath, DEFAULT_SIGNALING_CONFIG.peerJsPath),
+    peerJsSecure: coerceBool(src.peerJsSecure, DEFAULT_SIGNALING_CONFIG.peerJsSecure)
+  };
+}
+
+function ensureTrailingSlash(base) {
+  if (!base) return base;
+  return base.endsWith('/') ? base : base + '/';
+}
+
+function buildViewerUrl(peerId, inputConfig) {
+  if (!peerId) return '';
+  const config = normalizeSignalingConfig(inputConfig);
+  let url;
+  try {
+    url = new URL(ensureTrailingSlash(config.viewerUrlBase));
+  } catch (e) {
+    url = new URL(DEFAULT_SIGNALING_CONFIG.viewerUrlBase);
+  }
+  url.searchParams.set('host', peerId);
+  if (config.peerJsHost !== DEFAULT_SIGNALING_CONFIG.peerJsHost) {
+    url.searchParams.set('peerJsHost', config.peerJsHost);
+  }
+  if (config.peerJsPort !== DEFAULT_SIGNALING_CONFIG.peerJsPort) {
+    url.searchParams.set('peerJsPort', String(config.peerJsPort));
+  }
+  if (config.peerJsPath !== DEFAULT_SIGNALING_CONFIG.peerJsPath) {
+    url.searchParams.set('peerJsPath', config.peerJsPath);
+  }
+  if (config.peerJsSecure !== DEFAULT_SIGNALING_CONFIG.peerJsSecure) {
+    url.searchParams.set('peerJsSecure', config.peerJsSecure ? 'true' : 'false');
+  }
+  return url.toString();
+}
+
+function parseSignalingConfigFromParams(params) {
+  if (!params || typeof params.get !== 'function') {
+    return normalizeSignalingConfig({});
+  }
+  return normalizeSignalingConfig({
+    peerJsHost: params.get('peerJsHost'),
+    peerJsPort: params.get('peerJsPort'),
+    peerJsPath: params.get('peerJsPath'),
+    peerJsSecure: params.get('peerJsSecure')
+  });
+}
+
+function peerJsOptionsFromConfig(inputConfig) {
+  const config = normalizeSignalingConfig(inputConfig);
+  return {
+    host: config.peerJsHost,
+    port: config.peerJsPort,
+    path: config.peerJsPath,
+    secure: config.peerJsSecure
+  };
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    DEFAULT_SIGNALING_CONFIG,
+    SIGNALING_STORAGE_KEYS,
+    normalizeSignalingConfig,
+    buildViewerUrl,
+    parseSignalingConfigFromParams,
+    peerJsOptionsFromConfig
+  };
+}

--- a/client/viewer.js
+++ b/client/viewer.js
@@ -54,6 +54,9 @@ let viewportFollowTimer = null;
 const params = new URLSearchParams(location.search);
 const initialPeerId = params.get('host');
 const debugEnabled = params.get('debug') === 'true';
+const viewerSignalingConfig = (typeof parseSignalingConfigFromParams === 'function')
+  ? parseSignalingConfigFromParams(params)
+  : null;
 
 // Debug-gated logging - silences viewer console output unless ?debug=true
 const log = debugEnabled ? console.log.bind(console) : () => {};
@@ -98,7 +101,10 @@ function connect(hostPeerId) {
     : '';
   setStatus(reconnectAttempts > 0 ? 'Reconnecting...' : 'Connecting...', reconnectAttempts > 0 ? 'reconnecting' : 'connecting');
 
-  peer = new Peer();
+  const peerOptions = (viewerSignalingConfig && typeof peerJsOptionsFromConfig === 'function')
+    ? peerJsOptionsFromConfig(viewerSignalingConfig)
+    : undefined;
+  peer = peerOptions ? new Peer(undefined, peerOptions) : new Peer();
 
   peer.on('open', () => {
     dataConn = peer.connect(hostPeerId, { reliable: true });

--- a/client/viewer/index.html
+++ b/client/viewer/index.html
@@ -254,6 +254,7 @@
       window.location = '/';
     }
   </script>
+  <script src="../lib/signaling-config.js"></script>
   <script src="../lib/viewer-utils.js"></script>
   <script src="../viewer.js"></script>
 </body>

--- a/lib/bridge-utils.js
+++ b/lib/bridge-utils.js
@@ -4,11 +4,12 @@
 // Classic-script-compatible: defines functions at script scope so the
 // extension (bridge.html -> bridge.js) can pick them up as globals, and
 // exports via CommonJS so Vitest can import them in Node.
-
-function buildViewerUrl(peerId) {
-  if (!peerId) return '';
-  return `https://lobsterl.ink/?host=${encodeURIComponent(peerId)}`;
-}
+//
+// The canonical `buildViewerUrl` lives in `lib/signaling-config.js`. In the
+// browser the bridge page loads `signaling-config.js` before this file, so
+// `buildViewerUrl` is already defined as a global by the time bridge.js runs.
+// In Vitest we require the sibling module directly and re-export it for
+// tests that previously imported `buildViewerUrl` from this file.
 
 function pickDefaultSelectedTab(state) {
   const tabs = state && state.tabs;
@@ -22,5 +23,6 @@ function pickDefaultSelectedTab(state) {
 }
 
 if (typeof module !== 'undefined' && module.exports) {
+  const { buildViewerUrl } = require('./signaling-config.js');
   module.exports = { buildViewerUrl, pickDefaultSelectedTab };
 }

--- a/lib/signaling-config.js
+++ b/lib/signaling-config.js
@@ -1,0 +1,138 @@
+'use strict';
+
+// LobsterLink signaling-config helper.
+// Shared across the service worker (importScripts), the offscreen document,
+// the bridge page, the options page, and the viewer client — plus Vitest.
+// Defines normalization, URL-param round-tripping, and viewer URL building
+// so host/viewer stay aligned when pointed at self-hosted infrastructure.
+
+const DEFAULT_SIGNALING_CONFIG = {
+  viewerUrlBase: 'https://lobsterl.ink/',
+  peerJsHost: '0.peerjs.com',
+  peerJsPort: 443,
+  peerJsPath: '/',
+  peerJsSecure: true
+};
+
+const SIGNALING_STORAGE_KEYS = Object.freeze([
+  'viewerUrlBase',
+  'peerJsHost',
+  'peerJsPort',
+  'peerJsPath',
+  'peerJsSecure'
+]);
+
+function coerceString(value, fallback) {
+  if (typeof value !== 'string') return fallback;
+  const trimmed = value.trim();
+  return trimmed === '' ? fallback : trimmed;
+}
+
+function coercePort(value, fallback) {
+  if (value === null || value === undefined || value === '') return fallback;
+  const n = Number(value);
+  if (!Number.isFinite(n)) return fallback;
+  const int = Math.trunc(n);
+  if (int < 1 || int > 65535) return fallback;
+  return int;
+}
+
+function coerceBool(value, fallback) {
+  if (typeof value === 'boolean') return value;
+  if (value === 'true' || value === '1' || value === 1) return true;
+  if (value === 'false' || value === '0' || value === 0) return false;
+  return fallback;
+}
+
+function coercePath(value, fallback) {
+  if (typeof value !== 'string') return fallback;
+  const trimmed = value.trim();
+  if (trimmed === '') return fallback;
+  return trimmed.startsWith('/') ? trimmed : '/' + trimmed;
+}
+
+function coerceViewerUrlBase(value, fallback) {
+  const str = coerceString(value, null);
+  if (!str) return fallback;
+  try {
+    const parsed = new URL(str);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return fallback;
+    return str;
+  } catch (e) {
+    return fallback;
+  }
+}
+
+function normalizeSignalingConfig(input) {
+  const src = input || {};
+  return {
+    viewerUrlBase: coerceViewerUrlBase(src.viewerUrlBase, DEFAULT_SIGNALING_CONFIG.viewerUrlBase),
+    peerJsHost: coerceString(src.peerJsHost, DEFAULT_SIGNALING_CONFIG.peerJsHost),
+    peerJsPort: coercePort(src.peerJsPort, DEFAULT_SIGNALING_CONFIG.peerJsPort),
+    peerJsPath: coercePath(src.peerJsPath, DEFAULT_SIGNALING_CONFIG.peerJsPath),
+    peerJsSecure: coerceBool(src.peerJsSecure, DEFAULT_SIGNALING_CONFIG.peerJsSecure)
+  };
+}
+
+function ensureTrailingSlash(base) {
+  if (!base) return base;
+  return base.endsWith('/') ? base : base + '/';
+}
+
+function buildViewerUrl(peerId, inputConfig) {
+  if (!peerId) return '';
+  const config = normalizeSignalingConfig(inputConfig);
+  let url;
+  try {
+    url = new URL(ensureTrailingSlash(config.viewerUrlBase));
+  } catch (e) {
+    url = new URL(DEFAULT_SIGNALING_CONFIG.viewerUrlBase);
+  }
+  url.searchParams.set('host', peerId);
+  if (config.peerJsHost !== DEFAULT_SIGNALING_CONFIG.peerJsHost) {
+    url.searchParams.set('peerJsHost', config.peerJsHost);
+  }
+  if (config.peerJsPort !== DEFAULT_SIGNALING_CONFIG.peerJsPort) {
+    url.searchParams.set('peerJsPort', String(config.peerJsPort));
+  }
+  if (config.peerJsPath !== DEFAULT_SIGNALING_CONFIG.peerJsPath) {
+    url.searchParams.set('peerJsPath', config.peerJsPath);
+  }
+  if (config.peerJsSecure !== DEFAULT_SIGNALING_CONFIG.peerJsSecure) {
+    url.searchParams.set('peerJsSecure', config.peerJsSecure ? 'true' : 'false');
+  }
+  return url.toString();
+}
+
+function parseSignalingConfigFromParams(params) {
+  if (!params || typeof params.get !== 'function') {
+    return normalizeSignalingConfig({});
+  }
+  return normalizeSignalingConfig({
+    peerJsHost: params.get('peerJsHost'),
+    peerJsPort: params.get('peerJsPort'),
+    peerJsPath: params.get('peerJsPath'),
+    peerJsSecure: params.get('peerJsSecure')
+  });
+}
+
+function peerJsOptionsFromConfig(inputConfig) {
+  const config = normalizeSignalingConfig(inputConfig);
+  return {
+    host: config.peerJsHost,
+    port: config.peerJsPort,
+    path: config.peerJsPath,
+    secure: config.peerJsSecure
+  };
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    DEFAULT_SIGNALING_CONFIG,
+    SIGNALING_STORAGE_KEYS,
+    normalizeSignalingConfig,
+    buildViewerUrl,
+    parseSignalingConfigFromParams,
+    peerJsOptionsFromConfig
+  };
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "LobsterLink",
-  "version": "4.20.17.48",
+  "version": "4.21.10.10",
   "description": "Remote browser tab viewing and control via WebRTC",
   "permissions": [
     "tabs",
@@ -23,6 +23,10 @@
   "action": {
     "default_popup": "popup.html",
     "default_title": "LobsterLink"
+  },
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": true
   },
   "icons": {},
   "web_accessible_resources": []

--- a/offscreen.html
+++ b/offscreen.html
@@ -3,6 +3,7 @@
 <head><title>LobsterLink Offscreen</title></head>
 <body>
   <script src="lib/peerjs.min.js"></script>
+  <script src="lib/signaling-config.js"></script>
   <script src="offscreen.js"></script>
 </body>
 </html>

--- a/offscreen.js
+++ b/offscreen.js
@@ -24,6 +24,7 @@ let lastFrameData = null; // stores last base64 JPEG for redraw on viewer connec
 let frameTickerInterval = null;
 let frameTickerFlip = false;
 let screencastViewport = { width: 1920, height: 1080 };
+let activeSignalingConfig = null;
 
 const INPUT_TYPES = new Set(['mouse', 'key', 'clipboard']);
 
@@ -64,7 +65,7 @@ async function tuneCurrentVideoSender() {
 
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   if (msg.action === 'offscreen:startHostScreencast') {
-    startHostScreencast(msg.width, msg.height, msg.viewportWidth, msg.viewportHeight);
+    startHostScreencast(msg.width, msg.height, msg.viewportWidth, msg.viewportHeight, msg.signalingConfig);
     sendResponse({ ok: true });
     return false;
   }
@@ -106,7 +107,9 @@ function sendToViewer(message) {
 // --- PeerJS setup ---
 
 function setupPeer() {
-  peer = new Peer();
+  const peerOptions = peerJsOptionsFromConfig(activeSignalingConfig);
+  log('[LOBSTERLINK:offscreen] Peer options:', peerOptions.host, peerOptions.port, peerOptions.path, peerOptions.secure);
+  peer = new Peer(undefined, peerOptions);
 
   peer.on('open', (id) => {
     log('[LOBSTERLINK:offscreen] Peer ready, id:', id);
@@ -211,7 +214,8 @@ function sendViewportInfo() {
 
 // --- Screencast canvas mode ---
 
-function startHostScreencast(width, height, viewportWidth = width, viewportHeight = height) {
+function startHostScreencast(width, height, viewportWidth = width, viewportHeight = height, incomingSignalingConfig = null) {
+  activeSignalingConfig = incomingSignalingConfig || null;
   screencastViewport.width = viewportWidth || width;
   screencastViewport.height = viewportHeight || height;
   log('[LOBSTERLINK:offscreen] Starting host (screencast), canvas:', width, 'x', height,

--- a/options.html
+++ b/options.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>LobsterLink Signaling Settings</title>
+  <style>
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      padding: 24px;
+      font-family: system-ui, sans-serif;
+      font-size: 14px;
+      color: #e8eefc;
+      background:
+        radial-gradient(circle at top left, rgba(95, 140, 255, 0.14), transparent 34%),
+        radial-gradient(circle at top right, rgba(47, 199, 161, 0.10), transparent 30%),
+        linear-gradient(180deg, #0b1020 0%, #0d1326 100%);
+      min-height: 100vh;
+    }
+    .wrap {
+      max-width: 640px;
+      margin: 0 auto;
+    }
+    h1 {
+      margin: 0 0 4px;
+      font-size: 22px;
+      color: #fff;
+    }
+    p.lead {
+      margin: 0 0 20px;
+      color: #b0bcd8;
+      font-size: 14px;
+      line-height: 1.55;
+    }
+    .card {
+      background: rgba(21, 33, 64, 0.78);
+      border: 1px solid rgba(95, 140, 255, 0.28);
+      border-radius: 12px;
+      padding: 20px;
+    }
+    .field {
+      display: block;
+      margin-bottom: 14px;
+    }
+    .field label {
+      display: block;
+      font-size: 12px;
+      color: #9fb0d6;
+      margin-bottom: 4px;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+    .field input[type="text"],
+    .field input[type="number"] {
+      width: 100%;
+      padding: 8px 10px;
+      background: #0f1730;
+      border: 1px solid #2a3b66;
+      border-radius: 6px;
+      color: #fff;
+      font-size: 14px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    }
+    .field input:focus {
+      outline: none;
+      border-color: #5c85ff;
+    }
+    .field .hint {
+      margin-top: 4px;
+      font-size: 12px;
+      color: #8292b9;
+    }
+    .row {
+      display: flex;
+      gap: 12px;
+      align-items: center;
+    }
+    .row .field { flex: 1; margin-bottom: 0; }
+    .checkbox-field {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 14px;
+    }
+    .checkbox-field input {
+      width: 16px;
+      height: 16px;
+      accent-color: #5c85ff;
+    }
+    .actions {
+      margin-top: 20px;
+      display: flex;
+      gap: 10px;
+      align-items: center;
+    }
+    button {
+      padding: 10px 18px;
+      border: none;
+      border-radius: 8px;
+      background: linear-gradient(180deg, #6994ff, #4b71dc);
+      color: #fff;
+      font-size: 14px;
+      font-weight: 600;
+      cursor: pointer;
+    }
+    button:hover { filter: brightness(1.08); }
+    button.secondary {
+      background: #1a2543;
+      color: #c8d6ff;
+      border: 1px solid #2f3f70;
+    }
+    .status {
+      margin-left: auto;
+      font-size: 13px;
+      color: #8292b9;
+    }
+    .status.ok { color: #5cd6a5; }
+    .status.error { color: #f07878; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>LobsterLink Signaling Settings</h1>
+    <p class="lead">
+      Point the extension at a self-hosted PeerJS signaling server and a custom viewer URL
+      (for example, one served from your Tailscale network). Leave the defaults to use the
+      public LobsterLink infrastructure. Changes take effect the next time you start hosting.
+    </p>
+
+    <div class="card">
+      <div class="field">
+        <label for="viewerUrlBase">Viewer URL base</label>
+        <input type="text" id="viewerUrlBase" spellcheck="false" autocomplete="off" />
+        <div class="hint">Base URL where the viewer page is served, e.g. <code>https://lobsterl.ink/</code> or <code>http://vier:9000/</code>. Must be http(s).</div>
+      </div>
+
+      <div class="row">
+        <div class="field">
+          <label for="peerJsHost">PeerJS host</label>
+          <input type="text" id="peerJsHost" spellcheck="false" autocomplete="off" />
+        </div>
+        <div class="field" style="flex: 0 0 120px;">
+          <label for="peerJsPort">Port</label>
+          <input type="number" id="peerJsPort" min="1" max="65535" />
+        </div>
+      </div>
+
+      <div class="field">
+        <label for="peerJsPath">PeerJS path</label>
+        <input type="text" id="peerJsPath" spellcheck="false" autocomplete="off" />
+      </div>
+
+      <div class="checkbox-field">
+        <input type="checkbox" id="peerJsSecure" />
+        <label for="peerJsSecure" style="margin: 0; text-transform: none; letter-spacing: 0; color: #e8eefc; font-size: 14px;">
+          Use TLS (<code>secure: true</code> — required for HTTPS viewer URLs)
+        </label>
+      </div>
+
+      <div class="actions">
+        <button id="save">Save</button>
+        <button id="reset" class="secondary" type="button">Reset to defaults</button>
+        <span id="status" class="status"></span>
+      </div>
+    </div>
+  </div>
+
+  <script src="lib/signaling-config.js"></script>
+  <script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const els = {
+  viewerUrlBase: document.getElementById('viewerUrlBase'),
+  peerJsHost: document.getElementById('peerJsHost'),
+  peerJsPort: document.getElementById('peerJsPort'),
+  peerJsPath: document.getElementById('peerJsPath'),
+  peerJsSecure: document.getElementById('peerJsSecure'),
+  save: document.getElementById('save'),
+  reset: document.getElementById('reset'),
+  status: document.getElementById('status')
+};
+
+let statusTimer = null;
+function setStatus(text, tone = '') {
+  els.status.textContent = text || '';
+  els.status.className = `status${tone ? ` ${tone}` : ''}`;
+  if (statusTimer) clearTimeout(statusTimer);
+  if (text) {
+    statusTimer = setTimeout(() => {
+      els.status.textContent = '';
+      els.status.className = 'status';
+    }, 2500);
+  }
+}
+
+function populate(config) {
+  const normalized = normalizeSignalingConfig(config);
+  els.viewerUrlBase.value = normalized.viewerUrlBase;
+  els.peerJsHost.value = normalized.peerJsHost;
+  els.peerJsPort.value = String(normalized.peerJsPort);
+  els.peerJsPath.value = normalized.peerJsPath;
+  els.peerJsSecure.checked = !!normalized.peerJsSecure;
+}
+
+async function load() {
+  const stored = await chrome.storage.local.get(DEFAULT_SIGNALING_CONFIG);
+  populate(stored);
+}
+
+async function save() {
+  const input = {
+    viewerUrlBase: els.viewerUrlBase.value,
+    peerJsHost: els.peerJsHost.value,
+    peerJsPort: els.peerJsPort.value,
+    peerJsPath: els.peerJsPath.value,
+    peerJsSecure: els.peerJsSecure.checked
+  };
+  const normalized = normalizeSignalingConfig(input);
+  await chrome.storage.local.set(normalized);
+  populate(normalized);
+  setStatus('Saved', 'ok');
+}
+
+async function resetDefaults() {
+  await chrome.storage.local.set(DEFAULT_SIGNALING_CONFIG);
+  populate(DEFAULT_SIGNALING_CONFIG);
+  setStatus('Reset to defaults', 'ok');
+}
+
+els.save.addEventListener('click', () => {
+  save().catch((err) => setStatus(err.message || 'Save failed', 'error'));
+});
+els.reset.addEventListener('click', () => {
+  resetDefaults().catch((err) => setStatus(err.message || 'Reset failed', 'error'));
+});
+
+load().catch((err) => setStatus(err.message || 'Load failed', 'error'));

--- a/popup.html
+++ b/popup.html
@@ -135,8 +135,10 @@
 
   <div class="footer-actions">
     <button class="footer-btn" id="btn-bridge">Open Bridge</button>
+    <button class="footer-btn" id="btn-options" style="margin-top: 8px;">Signaling Settings</button>
   </div>
 
+  <script src="lib/signaling-config.js"></script>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -2,6 +2,7 @@ const modeSelect = document.getElementById('mode-select');
 const hostPanel = document.getElementById('host-panel');
 const viewerPanel = document.getElementById('viewer-panel');
 const bridgeButton = document.getElementById('btn-bridge');
+const optionsButton = document.getElementById('btn-options');
 
 function showPanel(panel) {
   modeSelect.style.display = 'none';
@@ -18,6 +19,14 @@ document.getElementById('viewer-back').addEventListener('click', () => showPanel
 bridgeButton.addEventListener('click', async () => {
   const url = chrome.runtime.getURL('bridge.html');
   await chrome.tabs.create({ url });
+  setTimeout(() => window.close(), 150);
+});
+optionsButton.addEventListener('click', () => {
+  if (chrome.runtime.openOptionsPage) {
+    chrome.runtime.openOptionsPage();
+  } else {
+    chrome.tabs.create({ url: chrome.runtime.getURL('options.html') });
+  }
   setTimeout(() => window.close(), 150);
 });
 
@@ -90,8 +99,9 @@ viewerConnect.addEventListener('click', async () => {
   viewerConnect.disabled = true;
   viewerStatus.textContent = 'Opening viewer...';
 
-  // Open public LobsterLink viewer
-  const url = `https://lobsterl.ink/?host=${encodeURIComponent(peerId)}`;
+  // Build viewer URL from configured base + signaling params (defaults to public host)
+  const stored = await chrome.storage.local.get(DEFAULT_SIGNALING_CONFIG);
+  const url = buildViewerUrl(peerId, stored);
   chrome.tabs.create({ url });
 
   // Close popup after short delay

--- a/test/bridge-utils.test.js
+++ b/test/bridge-utils.test.js
@@ -13,8 +13,10 @@ describe('buildViewerUrl', () => {
   });
 
   it('percent-encodes peer ids that contain reserved characters', () => {
+    // URLSearchParams serializes spaces as `+` and reserved chars as %-escapes.
+    // PeerJS sees the same decoded string either way.
     expect(buildViewerUrl('peer id/with+chars&more=')).toBe(
-      'https://lobsterl.ink/?host=peer%20id%2Fwith%2Bchars%26more%3D'
+      'https://lobsterl.ink/?host=peer+id%2Fwith%2Bchars%26more%3D'
     );
   });
 });

--- a/test/signaling-config.test.js
+++ b/test/signaling-config.test.js
@@ -1,0 +1,182 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_SIGNALING_CONFIG,
+  SIGNALING_STORAGE_KEYS,
+  normalizeSignalingConfig,
+  buildViewerUrl,
+  parseSignalingConfigFromParams,
+  peerJsOptionsFromConfig
+} from '../lib/signaling-config.js';
+
+describe('DEFAULT_SIGNALING_CONFIG', () => {
+  it('has the documented default values', () => {
+    expect(DEFAULT_SIGNALING_CONFIG).toEqual({
+      viewerUrlBase: 'https://lobsterl.ink/',
+      peerJsHost: '0.peerjs.com',
+      peerJsPort: 443,
+      peerJsPath: '/',
+      peerJsSecure: true
+    });
+  });
+
+  it('exports every default key in SIGNALING_STORAGE_KEYS', () => {
+    expect([...SIGNALING_STORAGE_KEYS].sort()).toEqual(
+      Object.keys(DEFAULT_SIGNALING_CONFIG).sort()
+    );
+  });
+});
+
+describe('normalizeSignalingConfig', () => {
+  it('returns defaults for undefined/null/empty input', () => {
+    expect(normalizeSignalingConfig()).toEqual(DEFAULT_SIGNALING_CONFIG);
+    expect(normalizeSignalingConfig(null)).toEqual(DEFAULT_SIGNALING_CONFIG);
+    expect(normalizeSignalingConfig({})).toEqual(DEFAULT_SIGNALING_CONFIG);
+  });
+
+  it('trims string fields and rejects empty strings', () => {
+    const result = normalizeSignalingConfig({
+      viewerUrlBase: '  https://vier:9000/  ',
+      peerJsHost: ' vier ',
+      peerJsPath: '   '
+    });
+    expect(result.viewerUrlBase).toBe('https://vier:9000/');
+    expect(result.peerJsHost).toBe('vier');
+    expect(result.peerJsPath).toBe('/');
+  });
+
+  it('rejects non-http(s) viewerUrlBase and falls back to default', () => {
+    expect(normalizeSignalingConfig({ viewerUrlBase: 'ftp://example.com/' }).viewerUrlBase)
+      .toBe(DEFAULT_SIGNALING_CONFIG.viewerUrlBase);
+    expect(normalizeSignalingConfig({ viewerUrlBase: 'not a url' }).viewerUrlBase)
+      .toBe(DEFAULT_SIGNALING_CONFIG.viewerUrlBase);
+  });
+
+  it('coerces port strings to integers and rejects out-of-range', () => {
+    expect(normalizeSignalingConfig({ peerJsPort: '9001' }).peerJsPort).toBe(9001);
+    expect(normalizeSignalingConfig({ peerJsPort: 0 }).peerJsPort).toBe(443);
+    expect(normalizeSignalingConfig({ peerJsPort: 70000 }).peerJsPort).toBe(443);
+    expect(normalizeSignalingConfig({ peerJsPort: 'nope' }).peerJsPort).toBe(443);
+  });
+
+  it('normalizes peerJsPath to start with a slash', () => {
+    expect(normalizeSignalingConfig({ peerJsPath: 'myapp' }).peerJsPath).toBe('/myapp');
+    expect(normalizeSignalingConfig({ peerJsPath: '/myapp/' }).peerJsPath).toBe('/myapp/');
+  });
+
+  it('coerces peerJsSecure from various truthy/falsy representations', () => {
+    expect(normalizeSignalingConfig({ peerJsSecure: 'false' }).peerJsSecure).toBe(false);
+    expect(normalizeSignalingConfig({ peerJsSecure: 'true' }).peerJsSecure).toBe(true);
+    expect(normalizeSignalingConfig({ peerJsSecure: false }).peerJsSecure).toBe(false);
+    expect(normalizeSignalingConfig({ peerJsSecure: '0' }).peerJsSecure).toBe(false);
+    expect(normalizeSignalingConfig({ peerJsSecure: 'gibberish' }).peerJsSecure).toBe(true);
+  });
+});
+
+describe('buildViewerUrl', () => {
+  it('returns empty string when no peerId is provided', () => {
+    expect(buildViewerUrl('')).toBe('');
+    expect(buildViewerUrl(null)).toBe('');
+    expect(buildViewerUrl(undefined)).toBe('');
+  });
+
+  it('uses defaults when no config is given', () => {
+    expect(buildViewerUrl('abc123')).toBe('https://lobsterl.ink/?host=abc123');
+  });
+
+  it('omits signaling params when they match defaults (clean URLs)', () => {
+    expect(buildViewerUrl('abc123', DEFAULT_SIGNALING_CONFIG))
+      .toBe('https://lobsterl.ink/?host=abc123');
+  });
+
+  it('includes only the signaling params that differ from defaults', () => {
+    const url = buildViewerUrl('abc', {
+      viewerUrlBase: 'http://vier:9000/',
+      peerJsHost: 'vier',
+      peerJsPort: 9001,
+      peerJsPath: '/',
+      peerJsSecure: false
+    });
+    expect(url).toBe(
+      'http://vier:9000/?host=abc&peerJsHost=vier&peerJsPort=9001&peerJsSecure=false'
+    );
+  });
+
+  it('adds a trailing slash to a bare viewerUrlBase', () => {
+    const url = buildViewerUrl('abc', { viewerUrlBase: 'http://vier:9000' });
+    expect(url.startsWith('http://vier:9000/?host=abc')).toBe(true);
+  });
+
+  it('preserves a path on viewerUrlBase', () => {
+    const url = buildViewerUrl('abc', { viewerUrlBase: 'https://example.com/ll/' });
+    expect(url.startsWith('https://example.com/ll/?host=abc')).toBe(true);
+  });
+
+  it('falls back to the default viewerUrlBase when input is invalid', () => {
+    const url = buildViewerUrl('abc', { viewerUrlBase: 'ftp://bad/' });
+    expect(url).toBe('https://lobsterl.ink/?host=abc');
+  });
+});
+
+describe('parseSignalingConfigFromParams', () => {
+  it('returns defaults when no signaling params are present', () => {
+    const params = new URLSearchParams('host=abc');
+    expect(parseSignalingConfigFromParams(params)).toEqual(DEFAULT_SIGNALING_CONFIG);
+  });
+
+  it('parses partial signaling overrides and keeps other defaults', () => {
+    const params = new URLSearchParams(
+      'host=abc&peerJsHost=vier&peerJsPort=9001&peerJsSecure=false'
+    );
+    const result = parseSignalingConfigFromParams(params);
+    expect(result.peerJsHost).toBe('vier');
+    expect(result.peerJsPort).toBe(9001);
+    expect(result.peerJsSecure).toBe(false);
+    expect(result.peerJsPath).toBe(DEFAULT_SIGNALING_CONFIG.peerJsPath);
+  });
+
+  it('tolerates non-params input', () => {
+    expect(parseSignalingConfigFromParams(null)).toEqual(DEFAULT_SIGNALING_CONFIG);
+    expect(parseSignalingConfigFromParams({})).toEqual(DEFAULT_SIGNALING_CONFIG);
+  });
+
+  it('round-trips via buildViewerUrl', () => {
+    const source = {
+      viewerUrlBase: 'http://vier:9000/',
+      peerJsHost: 'vier',
+      peerJsPort: 9001,
+      peerJsPath: '/peerjs',
+      peerJsSecure: false
+    };
+    const url = buildViewerUrl('abc', source);
+    const parsed = parseSignalingConfigFromParams(new URL(url).searchParams);
+    expect(parsed.peerJsHost).toBe('vier');
+    expect(parsed.peerJsPort).toBe(9001);
+    expect(parsed.peerJsPath).toBe('/peerjs');
+    expect(parsed.peerJsSecure).toBe(false);
+  });
+});
+
+describe('peerJsOptionsFromConfig', () => {
+  it('maps defaults to the PeerJS cloud options', () => {
+    expect(peerJsOptionsFromConfig()).toEqual({
+      host: '0.peerjs.com',
+      port: 443,
+      path: '/',
+      secure: true
+    });
+  });
+
+  it('maps a self-hosted config to PeerJS constructor options', () => {
+    expect(peerJsOptionsFromConfig({
+      peerJsHost: 'vier',
+      peerJsPort: 9001,
+      peerJsPath: '/peerjs',
+      peerJsSecure: false
+    })).toEqual({
+      host: 'vier',
+      port: 9001,
+      path: '/peerjs',
+      secure: false
+    });
+  });
+});

--- a/viewer.html
+++ b/viewer.html
@@ -226,6 +226,7 @@
     </div>
   </div>
   <script src="lib/peerjs.min.js"></script>
+  <script src="lib/signaling-config.js"></script>
   <script src="lib/viewer-utils.js"></script>
   <script src="client/viewer.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add shared signaling config helpers, extension settings UI, and manifest wiring so viewer URL plus PeerJS host, port, path, and secure can be configured per install
- pass signaling config end to end from the extension host into the generated viewer URL, offscreen host peer, popup and bridge, and hosted viewer so self-hosted PeerJS works on both sides
- document the self-hosted flow, bump the extension version to 4.21.10.10, and add tests covering normalization, URL round-tripping, and PeerJS option mapping

## Verification Evidence
- **Tests:** `npm run test:run` -> 4 files, 44 tests passed
- **Branch state:** clean worktree before push, 1 commit on top of `master`
- **UI spot check:** rendered `options.html` and `popup.html` in the browser for a quick layout sanity check
- **Commit:** `d3c9316`

## Test Plan
- [ ] Open the extension options page and save a custom viewer URL plus PeerJS host, port, path, and secure
- [ ] Start hosting from the extension and confirm the generated viewer link includes the expected non-default signaling params
- [ ] Open the generated viewer link and verify host and viewer connect through the configured PeerJS server
- [ ] Confirm the default lobsterl.ink plus 0.peerjs.com flow still works when settings stay at defaults

Closes #2
